### PR TITLE
Add Jokes Service and Controller

### DIFF
--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/controllers/JokeController.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/controllers/JokeController.java
@@ -2,7 +2,43 @@ package edu.ucsb.cs156.spring.backenddemo.controllers;
 
 import org.springframework.web.bind.annotation.RestController;
 
+import edu.ucsb.cs156.spring.backenddemo.services.EarthquakeQueryService;
+import edu.ucsb.cs156.spring.backenddemo.services.JokeQueryService;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name="Jokes from https://v2.jokeapi.dev/")
+@Slf4j
 @RestController
+@RequestMapping("/api/jokes")
 public class JokeController {
     
+    ObjectMapper mapper = new ObjectMapper();
+
+    @Autowired
+    JokeQueryService jokeQueryService;
+
+    @Operation(summary = "Get jokes for a given category and amount", description = "JSON return format documented here: https://v2.jokeapi.dev/")
+    @GetMapping("/get")
+    public ResponseEntity<String> getJokes(
+        @Parameter(name="category", description="category of joke", example="Dark") @RequestParam String category,
+        @Parameter(name="numJokes", description="amount of jokes to get", example="2") @RequestParam int numJokes
+    ) throws JsonProcessingException {
+        log.info("getJokes: category={} numJokes={}", category, numJokes);
+        String result = jokeQueryService.getJSON(category, numJokes);
+        return ResponseEntity.ok().body(result);
+    }
+
 }

--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/JokeQueryService.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/JokeQueryService.java
@@ -15,7 +15,7 @@ public class JokeQueryService {
         restTemplate = restTemplateBuilder.build();
     }
 
-    public static final String ENDPOINT = "";
+    public static final String ENDPOINT = "https://v2.jokeapi.dev/joke/{category}?amount={numJokes}";
 
     public String getJSON(String category, int numJokes) throws HttpClientErrorException {
         return "";

--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/JokeQueryService.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/JokeQueryService.java
@@ -1,11 +1,24 @@
 package edu.ucsb.cs156.spring.backenddemo.services;
 
-import org.springframework.boot.web.client.RestTemplateBuilder;
-import org.springframework.stereotype.Service;
-import org.springframework.web.client.HttpClientErrorException;
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import org.springframework.web.client.RestTemplate;
 
+import lombok.extern.slf4j.Slf4j;
 
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.HttpClientErrorException;
+
+@Slf4j
 @Service
 public class JokeQueryService {
 
@@ -15,9 +28,20 @@ public class JokeQueryService {
         restTemplate = restTemplateBuilder.build();
     }
 
-    public static final String ENDPOINT = "";
+    public static final String ENDPOINT = "https://v2.jokeapi.dev/joke/{category}?amount={numJokes}";
 
     public String getJSON(String category, int numJokes) throws HttpClientErrorException {
-        return "";
+        log.info("category={}, numJokes={}", category, numJokes);
+        HttpHeaders headers = new HttpHeaders();
+        headers.setAccept(List.of(MediaType.APPLICATION_JSON));
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+
+        Map<String, Object> uriVariables = Map.of("category", category, "numJokes", numJokes);  
+
+        ResponseEntity<String> re = restTemplate.exchange(ENDPOINT, HttpMethod.GET, entity, String.class,
+                uriVariables);
+        return re.getBody();
     }
 }

--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/JokeQueryService.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/JokeQueryService.java
@@ -36,9 +36,8 @@ public class JokeQueryService {
         headers.setAccept(List.of(MediaType.APPLICATION_JSON));
         headers.setContentType(MediaType.APPLICATION_JSON);
 
-        HttpEntity<String> entity = new HttpEntity<>(headers);
-
         Map<String, Object> uriVariables = Map.of("category", category, "numJokes", numJokes);  
+        HttpEntity<String> entity = new HttpEntity<>(headers);
 
         ResponseEntity<String> re = restTemplate.exchange(ENDPOINT, HttpMethod.GET, entity, String.class,
                 uriVariables);

--- a/src/test/java/edu/ucsb/cs156/spring/backenddemo/controllers/JokeControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/spring/backenddemo/controllers/JokeControllerTests.java
@@ -1,0 +1,53 @@
+package edu.ucsb.cs156.spring.backenddemo.controllers;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import edu.ucsb.cs156.spring.backenddemo.services.JokeQueryService;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.times;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+
+@WebMvcTest(value = JokeController.class)
+public class JokeControllerTests {
+  private ObjectMapper mapper = new ObjectMapper();
+  @Autowired
+  private MockMvc mockMvc;
+  @MockBean
+  JokeQueryService mockJokeQueryService;
+
+
+  @Test
+  public void test_getJokes() throws Exception {
+  
+    String fakeJsonResult="{ \"fake\" : \"result\" }";
+    String category = "Pun";
+    int numJokes = 3;
+    when(mockJokeQueryService.getJSON(eq(category),eq(numJokes))).thenReturn(fakeJsonResult);
+
+    String url = String.format("/api/jokes/get?category=%s&numJokes=%d",category,numJokes);
+
+    MvcResult response = mockMvc
+        .perform( get(url).contentType("application/json"))
+        .andExpect(status().isOk()).andReturn();
+
+    String responseString = response.getResponse().getContentAsString();
+
+    assertEquals(fakeJsonResult, responseString);
+  }
+
+}

--- a/src/test/java/edu/ucsb/cs156/spring/backenddemo/services/JokeQueryServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/spring/backenddemo/services/JokeQueryServiceTests.java
@@ -1,0 +1,41 @@
+package edu.ucsb.cs156.spring.backenddemo.services;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
+
+@RestClientTest(JokeQueryService.class)
+public class JokeQueryServiceTests {
+
+    @Autowired
+    private MockRestServiceServer mockRestServiceServer;
+
+    @Autowired
+    private JokeQueryService jokeQueryService;
+
+    @Test
+    public void test_getJSON() {
+
+        String category = "Pun";
+        int numJokes = 3;
+        String expectedURL = JokeQueryService.ENDPOINT.replace("{category}", category).replace("{numJokes}", "" + numJokes);
+
+        String fakeJsonResult = "{ \"fake\" : \"result\" }";
+
+        this.mockRestServiceServer.expect(requestTo(expectedURL))
+                .andExpect(header("Accept", MediaType.APPLICATION_JSON.toString()))
+                .andExpect(header("Content-Type", MediaType.APPLICATION_JSON.toString()))
+                .andRespond(withSuccess(fakeJsonResult, MediaType.APPLICATION_JSON));
+
+        String actualResult = jokeQueryService.getJSON(category, numJokes);
+        assertEquals(fakeJsonResult, actualResult);
+    }
+}


### PR DESCRIPTION
In this PR, we add an endpoint `/api/jokes/get` that can be used to get jokes for a given category and amount and a test for this controller.

Dev Deployment Links:
http://team01-ze-el-dev.dokku-13.cs.ucsb.edu
http://team01-ze-el-dev.dokku-13.cs.ucsb.edu/swagger-ui/index.html

Closes #7 